### PR TITLE
How to deploy theme-resources without mvn

### DIFF
--- a/magic-link/README.md
+++ b/magic-link/README.md
@@ -8,6 +8,8 @@ Screencast available here: https://youtu.be/oyUsI3QgEq8
 
 ## Usage
 
+<!-- is there a way to install this with the `theme-resources` without mvn? just adding the jar and running the jboss cli to add the module and extend the standalone-ha.xml. we add it to providers `/subsystem=keycloak-server:list-add(name=providers...` but don't know where/how to link the templates...?! just a hint would help me, then i'm happy to create clean MR with documentation :) -->
+
 1. Deploy to Keycloak:
 
     mvn clean install wildfly:deploy


### PR DESCRIPTION
Is there a way to install this with the `theme-resources` without mvn?

I just successfully added the JAR for the magic link using the jboss cli.

Added the module and then a new provider using `/subsystem=keycloak-server:list-add(name=providers...`.

But don't know where/how to link the templates... Just came across this https://issues.jboss.org/browse/KEYCLOAK-6519 and noticed its somewhat different from normal themes.

Just a hint would help me, then i'm happy to create clean MR with documentation :)