### PR TITLE
fixed maven build with keycloak 8 and upper

### DIFF
--- a/magic-link/src/main/java/org/keycloak/experimental/magic/MagicLinkFormAuthenticatorFactory.java
+++ b/magic-link/src/main/java/org/keycloak/experimental/magic/MagicLinkFormAuthenticatorFactory.java
@@ -36,7 +36,7 @@ public class MagicLinkFormAuthenticatorFactory implements AuthenticatorFactory {
 
     private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
         AuthenticationExecutionModel.Requirement.REQUIRED,
-        AuthenticationExecutionModel.Requirement.OPTIONAL,
+        AuthenticationExecutionModel.Requirement.CONDITIONAL,
         AuthenticationExecutionModel.Requirement.DISABLED
     };
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
     </licenses>
 
     <properties>
-        <version.keycloak>4.8.3.Final</version.keycloak>
-        <version.wildfly.maven.plugin>1.1.0.Final</version.wildfly.maven.plugin>
+        <version.keycloak>16.1.1</version.keycloak>
+        <version.wildfly.maven.plugin>2.1.0.Final</version.wildfly.maven.plugin>
     </properties>
 
     <modules>


### PR DESCRIPTION
It builds until 7.1 version:

https://access.redhat.com/webassets/avalon/d/red-hat-single-sign-on/version-7.1/javadocs/org/keycloak/models/AuthenticationExecutionModel.Requirement.html

It break down since 8.0 version:

https://www.keycloak.org/docs-api/9.0/javadocs/org/keycloak/models/AuthenticationExecutionModel.Requirement.html

OPTIONAL has became CONDITIONAL 

```
[INFO] -------------------------------------------------------------                                                                                                                 

[INFO] ------------------------------------------------------------------------                                                                                                      

[INFO] Reactor Summary for Keycloak Experimental Parent 0.1-SNAPSHOT:                                                                                                                

[INFO]                                                                                                                                                                               

[INFO] Keycloak Experimental Parent ....................... SUCCESS [  3.881 s]                                                                                                      

[INFO] Magic Link ......................................... FAILURE [ 29.272 s]                                                                                                      

[INFO] ------------------------------------------------------------------------                                                                                                      

[INFO] BUILD FAILURE                                                                                                                                                                 

[INFO] ------------------------------------------------------------------------                                                                                                      

[INFO] Total time:  34.536 s                                                                                                                                                         

[INFO] Finished at: 2022-03-18T14:47:32Z                                                                                                                                             

[INFO] ------------------------------------------------------------------------                                                                                                      

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:compile (default-compile) on project magic-link: Compilation failure                             

[ERROR] /usr/src/mymaven/magic-link/src/main/java/org/keycloak/experimental/magic/MagicLinkFormAuthenticatorFactory.java:[39,48] error: cannot find symbol    

```